### PR TITLE
Link logo/title in navbar to vespawatch.be

### DIFF
--- a/src/components/NavbarComponent.vue
+++ b/src/components/NavbarComponent.vue
@@ -1,7 +1,7 @@
 <template>
   <nav class="navbar navbar-expand-lg navbar-light bg-light">
     <div class="container-fluid">
-      <a class="navbar-brand d-flex align-items-center" href="/">
+      <a class="navbar-brand d-flex align-items-center" href="https://vespawatch.be">
         <img class="me-3" src="../assets/logo.png" alt="Vespa-Watch">
         Vespa-Watch
       </a>


### PR DESCRIPTION
Users currently have no way to go to the main https://vespawatch.be website. It's best they can do that by clicking the vespa-watch name and logo in the navbar.

@stevegerrits I don't think this is defined anywhere else then here, but if so, please correct.