### PR TITLE
Use 1px border (cf. Bootstrap outline)

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -107,7 +107,6 @@
     background-color: rgba(var(--v-theme-success));
 }
 
-/* Gefixt: "bezocht" status krijgt witte achtergrond met groene rand */
 .bg-visited { 
     background-color: #FFFFFF !important;
     border: 2px solid #198754 !important;
@@ -117,7 +116,7 @@
 /* Voor badges met de "bezocht" status */
 .badge.bg-visited {
     background-color: #FFFFFF !important;
-    border: 2px solid #198754 !important;
+    border: 1px solid #198754 !important;
     color: #198754 !important;
 }
 


### PR DESCRIPTION
See #397, reduces border in nest details:

<img width="407" alt="Screenshot 2025-06-10 at 12 14 11" src="https://github.com/user-attachments/assets/8f7f5076-25b7-4c8b-ba29-3577f583b3dd" />
